### PR TITLE
Fix publish-docs/action.yml syntax error for docs.yaml rename (!= ope…

### DIFF
--- a/publish-docs/action.yml
+++ b/publish-docs/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: "normalize the name of the doc"
       run: |
-        if [ inputs.doc_file_name -ne "docs.yaml" ];
+        if [ inputs.doc_file_name != "docs.yaml" ];
           then cp ${{ inputs.doc_file_name }} docs.yaml;
         fi
       shell: bash


### PR DESCRIPTION
…rator)